### PR TITLE
The Best Cython Videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,6 +316,7 @@ and for his valuable input in language design decisions.
         <li><a href="https://mail.python.org/mailman/listinfo/cython-devel">Core developer mailing list</a> and <a href="http://dir.gmane.org/gmane.comp.python.cython.devel">archive</a></li>
 	<li><a href="https://github.com/cython/cython/issues/">Bug &amp; Feature Tracker</a></li>
 	<li><a href="https://github.com/cython">Source code repositories</a> (using the Git DVCS)</li>
+	<li><a href="https://PythonLinks.info/cython">The Best Cython ideos</a></li>
 </ul>
 </p>
 


### PR DESCRIPTION
PythonLinks.info currently lists 17 Cython Videos.  They are ranked by upvotes vs total votes.  Swipe up and left to browse this branach of the tree, or use your keyboard arrow keys. 

Are there any other Cython videos you would like me to add to this collection?