### PR TITLE
This pull request addresses the following issue:

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
         <li><a href="#download">Download</a></li>
         <li><a href="#community">People</a></li>
         <li><a href="#development">Useful Links</a></li>
+	<li><a href="#videos">Videos</a></li>
       </ul>
     </div>
 
@@ -316,11 +317,16 @@ and for his valuable input in language design decisions.
         <li><a href="https://mail.python.org/mailman/listinfo/cython-devel">Core developer mailing list</a> and <a href="http://dir.gmane.org/gmane.comp.python.cython.devel">archive</a></li>
 	<li><a href="https://github.com/cython/cython/issues/">Bug &amp; Feature Tracker</a></li>
 	<li><a href="https://github.com/cython">Source code repositories</a> (using the Git DVCS)</li>
-	<li>Cython videos on <a href="https://pythonlinks.info/cython">PythonLinks</a> and <a href="https://pyvideo.org/search.html?q=cython">pyvideo.org</a></li>
+	<li>Cython videos on <a href="https://pyvideo.org/search.html?q=cython">pyvideo.org</a></li>
 </ul>
 </p>
 
-    </div>
+
+<a name="videos"></a>
+<div align="center">
+<iframe src="https://PythonLinks.info/cython/videos"> </iframe>
+</div>
+</div>
 
 <div class="testimonials" id="testimonials">
 <p style="font-weight: bold; font-size:120%">What users have to say about Cython:</p>

--- a/master.css
+++ b/master.css
@@ -206,3 +206,9 @@ padding:2px 7px;
 position:relative;
 top:10px
 }
+
+iframe {
+width:100%; 
+margin: 10px; 
+height: 100vh; 
+}


### PR DESCRIPTION
It is very hard for open source projects
to maintain current lists of the best  videos.
There are many Python conferences all over the world.  The best
videos keep changing.  One has to regularly call the YouTube
api's and sort the results to maintain the list.
One has to delete the old videos
when the products change sinificantly.

Fortunately PythonLinks.info/cython does all of this for you.
But that does not help the users browsing your site.

So I added an iFrame widget which displays the best Cython videos
organized into three different categories. As I index new conferences,
the changes will be displayed in this widget on the Cython home page.

Thanks
Chris