### PR TITLE
Update SciPy 2009 proceedings link

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,8 +130,8 @@ Here is a <strong>list</strong> of possible <a href="http://wiki.cython.org/enha
 <li><a href="https://shop.oreilly.com/product/0636920033431.do">Cython - A Guide for Python Programmers</a>, book by Kurt W. Smith, O'Reilly 2015</li>
 <li><a href="https://doi.ieeecomputersociety.org/10.1109/MCSE.2010.118">Cython: The best of both worlds</a>, article by Stefan Behnel, Robert Bradshaw et al., IEEE 2011</li>
 <li>SciPy 2009 proceedings (pdf):
-  <a href="https://conference.scipy.org/proceedings/SciPy2009/paper_1/">Cython Tutorial</a>;
-  <a href="https://conference.scipy.org/proceedings/SciPy2009/paper_2/">Fast Numerical Computations with Cython</a>
+  <a href="https://proceedings.scipy.org/articles/MJMV8092">Cython Tutorial</a>;
+  <a href="https://proceedings.scipy.org/articles/GTCA8577">Fast Numerical Computations with Cython</a>
 </li>
 </ul>
 </p>


### PR DESCRIPTION
Hi all.

I was going through the homepage and found that the SciPy 2009 proceedings links were incorrect. I've updated it.
Thanks for all the work! 